### PR TITLE
ignore_dh_make_orig_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ debhelper-build-stamp
 *.buildinfo
 *.changes
 *.tar.gz
+*.tar.xz
 *.log
 *.substvars
 /.vagrant


### PR DESCRIPTION
ignore .tar.xz files generated by dh_make --createorig